### PR TITLE
Add DeepSeek and oMLX backends, config-driven backend selection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,17 +1,38 @@
-# ─── ARANEA — Environment Configuration ───────────────────────────────────
+# ─── SEEKER — Environment Configuration ───────────────────────────────────
 # Copy this file to .env and fill in your API keys.
-# Only ANTHROPIC_API_KEY is required if using Claude. All others are optional.
+# Set the API key for whichever LLM backend you select; all others are optional.
 
-# ─── LLM Provider (choose one or both) ────────────────────────────────────
+# ─── LLM Backend Selection ─────────────────────────────────────────────────
+# Options: anthropic | deepseek | omlx | ollama
+# Precedence (high → low): --backend CLI flag, LLM_BACKEND env, config.json
+# llm.backend, then legacy auto-detect (anthropic if key set, else ollama).
+# LLM_BACKEND=
+#
+# Cross-backend fallback (opt-in). When the active backend's heavy AND light
+# models both fail, route to this backend instead of raising. Leave empty for
+# no cross-backend fallback (recommended — predictable cost / locality).
+# LLM_FALLBACK_BACKEND=
 
-# Anthropic Claude API (primary — required for full pipeline)
+# ─── Anthropic Claude API ──────────────────────────────────────────────────
 # Get your key: https://console.anthropic.com/settings/keys
+# Models: claude-sonnet-4-5 (heavy) / claude-haiku-4-5-20251001 (light)
 ANTHROPIC_API_KEY=
 
-# Ollama (local fallback — no key needed)
+# ─── DeepSeek (Anthropic-compatible API) ───────────────────────────────────
+# https://api-docs.deepseek.com/guides/anthropic_api
+# Get your key: https://platform.deepseek.com/api_keys
+# Models: deepseek-v4-pro (heavy) / deepseek-v4-flash (light)
+# DEEPSEEK_API_KEY=
+
+# ─── oMLX (local Anthropic-compatible server) ──────────────────────────────
+# Run: omlx serve --port 8000
+# Models: Qwen3.6-35B-A3B-4bit (heavy) / gemma-4-e4b-it-8bit (light)
+# OMLX_API_KEY=
+# OMLX_BASE_URL=http://127.0.0.1:8000
+
+# ─── Ollama (local, no key needed) ─────────────────────────────────────────
 # Install: https://ollama.com/download
-# Then: ollama pull qwen2.5:14b
-# The pipeline auto-detects Ollama on localhost:11434
+# Then: ollama pull deepseek-r1:8b && ollama pull llama3.2:3b
 # OLLAMA_HOST=http://localhost:11434
 
 # ─── Academic Source APIs ──────────────────────────────────────────────────

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,147 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Common Commands
+
+**One-time setup**: the ConceptNet DB ships compressed and must be unpacked before the first run.
+
+```bash
+cd db && gunzip conceptnet.db.gz && cd ..
+cp .env.example .env   # then add ANTHROPIC_API_KEY (or leave blank for Ollama-only)
+pip install -r requirements.txt
+```
+
+**Pipeline**:
+
+```bash
+python3 main.py run --problem "Your research question"
+python3 main.py run --problem "..." --run-id RUN-YYYYMMDD-XXXX --resume
+```
+
+**Other CLI subcommands** (all in [main.py](main.py)):
+
+| Command | Purpose |
+|---|---|
+| `run` | Full pipeline (10 agents + 3 breaks) |
+| `collect` | Social passive theme scan, no run_id |
+| `recheck` | Link health check across `sources` table |
+| `status --run-id RUN-...` | Show run progress + per-table counts |
+| `bank` | List Grounder's pending seminal-bank theme proposals |
+| `runs` | List recent runs |
+| `keys` | Show API key status |
+| `test --source <name> --query "..."` | Debug a single source handler |
+
+**Tests** — both patterns work; tests are pytest-compatible AND runnable as standalone scripts:
+
+```bash
+python3 -m pytest tests/ -v
+python3 tests/test_grounder_tree.py     # standalone-script style also works
+```
+
+**Evaluation tools** (in [tools/](tools/)): `eval_references.py`, `eval_claims.py`, `generate_references.py`, `export_seminal.py`, `import_conceptnet.py`.
+
+## Architecture
+
+### Pipeline orchestration
+
+[main.py](main.py) sequences 10 agents around 3 human breaks (Concept Mapper → Break 0 → Grounder → Social → Historian → Gaper → Break 1 → Vision → Theorist → Rude → Synthesizer → Break 2 → Thinker → Scribe). Each agent exposes `run(context, run_id)` and writes its results to its own DB table. **There is no direct data passing between agents** — downstream agents read what upstream agents wrote by querying the DB through [core/context.py](core/context.py) builders.
+
+### The argument tree is the spine
+
+[core/argument_tree.py](core/argument_tree.py) defines `TreeBuilder`, a SQLite-backed tree with 9 node types: `root`, `question`, `claim`, `evidence`, `bridge`, `counter`, `historical`, `external`, `audit_note`. Grounder **creates** the tree; every agent after Grounder may extend it (claims, counters, historical context, audit notes) and reads from it via the `for_<agent>()` context builders in [core/context.py](core/context.py).
+
+Evidence-specific fields (evidence type, relationship to the claim) live in a JSON `metadata` column, **not** as schema columns. When adding evidence, pass `evidence_type` and `relationship` as parameters; they're serialized into metadata. Read them back through `to_context()` formatting rather than querying metadata directly.
+
+### `--resume` is table-presence-based, not step-flag-based
+
+[`_agent_done()`](main.py:389) infers completion by checking whether the agent's output table has rows for that `run_id`:
+
+```
+grounder    → seminal sources
+social      → current sources
+historian   → historical sources
+gaper       → gaps
+vision      → implications
+theorist    → proposals
+rude        → evaluations
+synthesizer → synthesis row
+thinker     → directions
+scribe      → artifacts
+```
+
+**Implication**: if an agent partially fails (e.g., wrote 3 of 10 expected rows), `--resume` will **skip** it. To retry, manually `DELETE FROM <table> WHERE run_id = ...` first.
+
+Only the three breaks are tracked explicitly: `break0_done`, `break1_done`, `break2_done` in the `runs` table.
+
+### Two `breaks.py` files — don't conflate them
+
+- [core/breaks.py](core/breaks.py) — the **break flow**. Writes `artifacts/{run_id}_break{N}_review.md`, blocks on `input()`, parses instructions out of the markdown (under the `**Your instructions:**` marker), calls `db.mark_break_done()`, returns instructions string for the next agent's context.
+- [agents/breaks.py](agents/breaks.py) — **agent-side helpers** for interpreting break instructions inside agents.
+
+### LLM router ([core/llm.py](core/llm.py)) — four backends
+
+Four backends are supported. Three of them (`anthropic`, `deepseek`, `omlx`) share the same code path: an `Anthropic()` SDK client constructed with backend-specific `api_key=` and `base_url=`. Only `ollama` uses its own native HTTP transport.
+
+| Backend | Heavy / Light models | API key | Base URL |
+|---|---|---|---|
+| `anthropic` | `claude-sonnet-4-5` / `claude-haiku-4-5-20251001` | `ANTHROPIC_API_KEY` | SDK default |
+| `deepseek` | `deepseek-v4-pro` / `deepseek-v4-flash` | `DEEPSEEK_API_KEY` | `https://api.deepseek.com/anthropic` |
+| `omlx` | `Qwen3.6-35B-A3B-4bit` / `gemma-4-e4b-it-8bit` | `OMLX_API_KEY` | `http://127.0.0.1:8000` |
+| `ollama` | `deepseek-r1:8b` / `llama3.2:3b` | none | `http://localhost:11434` |
+
+**Important**: even though DeepSeek's docs say the `x-api-key` header is read from `ANTHROPIC_API_KEY`, the router pulls the key from `DEEPSEEK_API_KEY` and passes it to the SDK explicitly. Never expose `$ANTHROPIC_API_KEY` to non-Anthropic backends.
+
+**Backend selection (highest precedence first)**:
+1. `--backend` CLI flag on `main.py run`
+2. `LLM_BACKEND` env var
+3. `config.json` → `llm.backend`
+4. Legacy auto-detect: `anthropic` if `ANTHROPIC_API_KEY` is set, else `ollama`
+
+**Per-agent tier**: agents are tagged `heavy` or `light` in `AGENT_TIER`. Heavy agents call the heavy model and within-backend-fall-back to the light model on failure. Light agents go straight to the light model with no within-backend retry (it's already the cheap model). Per-agent token caps remain in `AGENT_MAX_TOKENS`.
+
+**Cross-backend fallback is opt-in**. Set `config.llm.fallback_backend` or `LLM_FALLBACK_BACKEND` to chain backends; default is `null`, meaning failure on the chosen backend raises rather than silently routing elsewhere. This is a deliberate behavior change from the older "always fall back to Ollama" path.
+
+The router is a lazily-initialized module-level singleton; tests can call `llm.reset_client()` after mutating env to rebuild it.
+
+### Database ([core/database.py](core/database.py)) — no migration system
+
+12 tables, schema bootstrapped once via `executescript(SCHEMA)` in `init_db()`. Adding or changing a column requires editing the `SCHEMA` constant **and** manually `ALTER TABLE`-ing any existing `db/pipeline.db`. There is no Alembic, no versioned migrations, no auto-upgrade.
+
+Many fields are JSON strings inside `TEXT` columns (`authors`, `theme_tags`, `addresses_gaps`, `assumptions`, etc.). Use the `_json()` / `_from_json()` helpers. `upsert_source()` uses `INSERT OR REPLACE` for idempotency.
+
+### Concept Mapper + Break 0
+
+[core/concept_mapper.py](core/concept_mapper.py) reads `concept_map.json` (37 semantic clusters) and activates themes from `config.json`. The activation is shown to the user at Break 0 for confirmation/editing **before any source search runs** — this is the only chance to scope the literature search.
+
+### Prompts are hardcoded in agent files
+
+Each agent in [agents/](agents/) defines its system prompt and user-prompt template as Python string literals. There is no separate prompts directory and no prompt versioning — editing a prompt is editing code. Output JSON parsing in every agent must include a fallback parser; LLM outputs (especially under Ollama) are best-effort.
+
+## Configuration & Environment
+
+- `config.json` — **theme registry only**: themes, their seed keywords, and the `agent_sources` map per agent. Not feature flags. Adding a theme = adding an entry here plus, if needed, a discipline mapping in `core/concept_mapper.py`'s `EXPLICIT_MAP`.
+- `concept_map.json` — 37 semantic clusters that translate problem statements into theme activations.
+- Required env: `ANTHROPIC_API_KEY` (or leave blank to run Ollama-only at `localhost:11434`).
+- Optional env: `OPENALEX_EMAIL`, `S2_API_KEY`, `SCOPUS_API_KEY` + `SCOPUS_INST_TOKEN`, `CORE_API_KEY`, `NCBI_API_KEY` + `NCBI_EMAIL`, `PHILPAPERS_API_ID` + `PHILPAPERS_API_KEY`, `OLLAMA_HOST`. See [.env.example](.env.example).
+- [main.py](main.py) calls `_load_env()` at the very top, **before** other imports. Any module that reads `os.environ` at import time must be imported after that call.
+
+## Conventions & Gotchas
+
+- **New source handler**: subclass `SourceHandler` in [agents/social.py](agents/social.py), set `SOURCE_ID`, implement `search(query, keywords, limit, run_id)` returning dicts with `title`, `authors`, `year`, `abstract`, `doi`, etc., register in the `SOURCE_HANDLERS` dict, then add the source name to the relevant theme's `sources` list (or to `agent_sources`) in `config.json`.
+- **Tree integrity**: every claim should have at least one evidence node. Orphan claims surface as "weak" or "unsupported" in Historian's audit pass.
+- `run_id` format is `RUN-YYYYMMDD-XXXX` and acts as the foreign key across all tables — never reuse one across distinct problems.
+- **Test isolation pattern** (no conftest, no fixtures): tests patch `at.DB_PATH` and `database.DB_PATH` to a `/tmp/test_*.db` path before importing the modules under test, then build minimal schema via `conn.executescript()`. Duplicate this pattern when adding tests.
+- The `pyproject.toml` script entry is named `aranea` — that's the legacy project name; the repo and code use `SEEKER`.
+
+## Critical Files
+
+- [main.py](main.py) — pipeline orchestration, CLI, `_agent_done()` resume logic
+- [core/argument_tree.py](core/argument_tree.py) — `TreeBuilder`
+- [core/database.py](core/database.py) — `SCHEMA` and DB helpers
+- [core/context.py](core/context.py) — per-agent context builders, tree injection
+- [core/breaks.py](core/breaks.py) — human-in-the-loop flow
+- [core/llm.py](core/llm.py) — Claude/Ollama routing, per-agent model selection
+- [core/concept_mapper.py](core/concept_mapper.py) — feeds Break 0
+- [config.json](config.json), [concept_map.json](concept_map.json) — runtime config
+- [.env.example](.env.example) — full env-var reference

--- a/README.md
+++ b/README.md
@@ -103,39 +103,43 @@ python3 main.py run --problem "your problem" --run-id RUN-20260407-022355-242D -
 
 The pipeline detects which agents already completed (by checking the database) and skips them.
 
-## Using Ollama (Free, Local, No API Key)
+## Choosing an LLM Backend
 
-SEEKER works with local models via [Ollama](https://ollama.com/) as a fallback. No cloud API needed.
+SEEKER supports four backends. Pick one with `--backend`, the `LLM_BACKEND` env var, or by editing `config.json`'s `llm.backend` field — the CLI flag wins, then the env var, then the config file, then legacy auto-detect (Anthropic if `ANTHROPIC_API_KEY` is set, else Ollama).
 
-### Setup
+| Backend | Heavy / Light | Cost / Locality | API key |
+|---|---|---|---|
+| `anthropic` | `claude-sonnet-4-5` / `claude-haiku-4-5-20251001` | Cloud, paid | `ANTHROPIC_API_KEY` |
+| `deepseek` | `deepseek-v4-pro` / `deepseek-v4-flash` (Anthropic-compatible endpoint) | Cloud, paid | `DEEPSEEK_API_KEY` |
+| `omlx` | `Qwen3.6-35B-A3B-4bit` / `gemma-4-e4b-it-8bit` | Local Anthropic-compatible server | `OMLX_API_KEY` |
+| `ollama` | `deepseek-r1:8b` / `llama3.2:3b` | Local, free | none |
 
 ```bash
-# Install Ollama
+python3 main.py run --problem "..." --backend deepseek
+LLM_BACKEND=omlx python3 main.py run --problem "..."
+```
+
+**Within-backend fallback** (heavy → light model) is automatic. **Cross-backend fallback is opt-in**: set `LLM_FALLBACK_BACKEND` or `config.json` `llm.fallback_backend` if you want failure on the chosen backend to route to a second backend instead of raising. The default is no cross-backend fallback — picking a backend means staying on it.
+
+### Local-only mode
+
+For Ollama:
+
+```bash
 curl -fsSL https://ollama.com/install.sh | sh
-
-# Pull a model (14B+ recommended for research quality)
-ollama pull qwen2.5:14b
-
-# Or a smaller model for testing
-ollama pull qwen2.5:7b
+ollama pull deepseek-r1:8b   # heavy
+ollama pull llama3.2:3b      # light
+LLM_BACKEND=ollama python3 main.py run --problem "..."
 ```
 
-### Configuration
+For oMLX (a local Anthropic-compatible server) you'd run `omlx serve --port 8000`, set `OMLX_API_KEY`, and pass `--backend omlx`.
 
-Leave `ANTHROPIC_API_KEY` empty in your `.env` file. The pipeline auto-detects Ollama on `localhost:11434` and uses it for all agents.
+### What to expect from local models
 
-```
-# .env — leave blank for Ollama-only mode
-ANTHROPIC_API_KEY=
-```
-
-### What to expect
-
-Local models (7B–14B) produce usable results but with lower quality than Claude:
+Local models produce usable results but with lower quality than the cloud options:
 - Sub-question decomposition may be shallower
 - JSON parsing failures are more frequent (the pipeline has fallback parsers)
 - Synthesis quality depends heavily on model size
-- 14B+ is recommended; 7B works but produces thin outputs
 
 The pipeline is designed to degrade gracefully — every JSON parser has a fallback, every agent has error handling, and the argument tree preserves whatever was successfully parsed.
 

--- a/config.json
+++ b/config.json
@@ -1,6 +1,32 @@
 {
   "_description": "Pipeline theme bank and source configuration. You maintain this manually.",
   "_version": "2.0",
+  "llm": {
+    "_doc": "Backend selection. Override at runtime with LLM_BACKEND env var or --backend CLI flag. fallback_backend is opt-in cross-backend fallback (null = no cross-backend fallback).",
+    "backend": "anthropic",
+    "fallback_backend": null,
+    "models": {
+      "anthropic": {
+        "heavy": "claude-sonnet-4-5",
+        "light": "claude-haiku-4-5-20251001"
+      },
+      "deepseek": {
+        "heavy": "deepseek-v4-pro",
+        "light": "deepseek-v4-flash",
+        "base_url": "https://api.deepseek.com/anthropic"
+      },
+      "omlx": {
+        "heavy": "Qwen3.6-35B-A3B-4bit",
+        "light": "gemma-4-e4b-it-8bit",
+        "base_url": "http://127.0.0.1:8000"
+      },
+      "ollama": {
+        "heavy": "deepseek-r1:8b",
+        "light": "llama3.2:3b",
+        "base_url": "http://localhost:11434"
+      }
+    }
+  },
   "themes": [
     {
       "theme_id": "philosophy_of_mind",

--- a/core/keys.py
+++ b/core/keys.py
@@ -82,6 +82,12 @@ def philpapers_key() -> str:
 def anthropic() -> str:
     return get("ANTHROPIC_API_KEY", required=True, source_name="Anthropic Claude API")
 
+def deepseek() -> str:
+    return get("DEEPSEEK_API_KEY", required=False, source_name="DeepSeek (Anthropic-compatible API)")
+
+def omlx() -> str:
+    return get("OMLX_API_KEY", required=False, source_name="oMLX (local Anthropic-compatible server)")
+
 def google_books() -> str:
     return get("GOOGLE_BOOKS_API_KEY", required=False, source_name="Google Books (optional — higher quota)")
 
@@ -111,8 +117,29 @@ def print_key_status():
         ("SCOPUS_API_KEY",          "Scopus",           False, "dev.elsevier.com → Create API Key"),
         ("SCOPUS_INST_TOKEN",        "Scopus Inst Token",False, "email datasupport@elsevier.com"),
         ("GOOGLE_BOOKS_API_KEY",    "Google Books",     False, "console.cloud.google.com → Books API"),
-        ("ANTHROPIC_API_KEY",       "Anthropic Claude", True,  "console.anthropic.com"),
+        ("ANTHROPIC_API_KEY",       "Anthropic Claude", False, "console.anthropic.com"),
+        ("DEEPSEEK_API_KEY",        "DeepSeek",         False, "platform.deepseek.com/api_keys"),
+        ("OMLX_API_KEY",            "oMLX (local)",     False, "your local oMLX server config"),
     ]
+
+    # LLM backend status header
+    try:
+        from core import llm as _llm
+        client = _llm.get_client()
+        active = client.active_backend()
+        fallback = client.fallback_backend()
+        ok, detail = client.active_backend_status()
+        backend_line = (
+            f"  Backend: {active} {'✅' if ok else '⚠️'} {detail}"
+            f"   (fallback: {fallback or 'none'})"
+        )
+    except Exception as e:
+        backend_line = f"  Backend: <error resolving — {e}>"
+
+    print(f"\n  {'─'*60}")
+    print(f"  LLM Backend")
+    print(f"  {'─'*60}")
+    print(backend_line)
     print(f"\n  {'─'*60}")
     print(f"  API Key Status")
     print(f"  {'─'*60}")

--- a/core/llm.py
+++ b/core/llm.py
@@ -1,15 +1,26 @@
 """
 LLM Router
 ----------
-Primary:  Claude API (Anthropic)
-Fallback: Ollama (local models)
+Four backends supported:
 
-Every agent calls llm.call(prompt, system, agent_name)
-The router handles retries, fallback, and logging transparently.
+  anthropic — Claude API (Anthropic SDK)
+  deepseek  — DeepSeek's Anthropic-compatible endpoint (Anthropic SDK + base_url)
+  omlx      — local oMLX server, Anthropic-compatible (Anthropic SDK + base_url)
+  ollama    — local Ollama, native /api/chat (requests)
+
+Backend selection (highest precedence first):
+  1. force_local=True kwarg                → ollama
+  2. LLM_BACKEND env var                   → that backend
+  3. config.json llm.backend               → that backend
+  4. Legacy auto-detect                    → anthropic if ANTHROPIC_API_KEY else ollama
+
+Within-backend fallback (heavy → light model) is automatic. Cross-backend
+fallback is opt-in via config.json llm.fallback_backend or LLM_FALLBACK_BACKEND.
+
+Every agent calls llm.call(prompt, system, agent_name).
 """
 
 import os
-import json
 import time
 import logging
 import requests
@@ -19,29 +30,19 @@ from anthropic import Anthropic, APIStatusError, APIConnectionError, RateLimitEr
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
-# Configuration
+# Constants
 # ---------------------------------------------------------------------------
 
-# Claude models — primary
-CLAUDE_PRIMARY_MODEL   = "claude-sonnet-4-5"
-CLAUDE_FALLBACK_MODEL  = "claude-haiku-4-5-20251001"  # cheaper fallback within API
+MAX_API_RETRIES     = 3
+RETRY_DELAY_SECONDS = 5
+MAX_TOKENS          = 8192
 
-# Ollama — local fallback
-OLLAMA_BASE_URL        = "http://localhost:11434"
-OLLAMA_PRIMARY_MODEL   = "deepseek-r1:8b"
-OLLAMA_LIGHT_MODEL     = "llama3.2:3b"
-
-# Retry settings
-MAX_API_RETRIES        = 3
-RETRY_DELAY_SECONDS    = 5
-MAX_TOKENS             = 8192
-
-# Per-agent token limits — agents with large structured JSON outputs need more
+# Per-agent token caps — agents with large structured JSON outputs need more.
 AGENT_MAX_TOKENS = {
-    "grounder":    16000,  # decomposition + multi-source search + large JSON
-    "theorist":    16000,  # multiple proposals each with full fields
-    "historian":   10000,  # chronological map can be long
-    "synthesizer": 10000,  # narrative + full bibliography
+    "grounder":    16000,
+    "theorist":    16000,
+    "historian":   10000,
+    "synthesizer": 10000,
     "gaper":       12000,
     "vision":      16000,
     "rude":        10000,
@@ -50,29 +51,58 @@ AGENT_MAX_TOKENS = {
     "scribe":      12000,
 }
 
-
-# ---------------------------------------------------------------------------
-# Agent → model mapping
-# Heavier reasoning agents get the primary model
-# Lighter formatting agents get the cheaper/faster model
-# ---------------------------------------------------------------------------
-
-AGENT_MODEL_MAP = {
-    # Heavy reasoning — always use primary Claude
-    "grounder":    {"claude": CLAUDE_PRIMARY_MODEL, "ollama": OLLAMA_PRIMARY_MODEL},
-    "historian":   {"claude": CLAUDE_PRIMARY_MODEL, "ollama": OLLAMA_PRIMARY_MODEL},
-    "gaper":       {"claude": CLAUDE_PRIMARY_MODEL, "ollama": OLLAMA_PRIMARY_MODEL},
-    "vision":      {"claude": CLAUDE_PRIMARY_MODEL, "ollama": OLLAMA_PRIMARY_MODEL},
-    "theorist":    {"claude": CLAUDE_PRIMARY_MODEL, "ollama": OLLAMA_PRIMARY_MODEL},
-    "rude":        {"claude": CLAUDE_PRIMARY_MODEL, "ollama": OLLAMA_PRIMARY_MODEL},
-    "synthesizer": {"claude": CLAUDE_PRIMARY_MODEL, "ollama": OLLAMA_PRIMARY_MODEL},
-    "thinker":     {"claude": CLAUDE_PRIMARY_MODEL, "ollama": OLLAMA_PRIMARY_MODEL},
-    # Lighter tasks — can use cheaper/faster model
-    "social":      {"claude": CLAUDE_FALLBACK_MODEL, "ollama": OLLAMA_LIGHT_MODEL},
-    "scribe":      {"claude": CLAUDE_FALLBACK_MODEL, "ollama": OLLAMA_LIGHT_MODEL},
+# Each agent runs on the heavy model (high reasoning) or the light model
+# (cheap formatting / extraction). Heavy agents get the within-backend
+# fallback (heavy → light) on failure; light agents are already on the cheap
+# model so retrying with the same model would be redundant.
+AGENT_TIER = {
+    "grounder":    "heavy",
+    "historian":   "heavy",
+    "gaper":       "heavy",
+    "vision":      "heavy",
+    "theorist":    "heavy",
+    "rude":        "heavy",
+    "synthesizer": "heavy",
+    "thinker":     "heavy",
+    "social":      "light",
+    "scribe":      "light",
 }
 
-DEFAULT_MODEL_ENTRY = {"claude": CLAUDE_PRIMARY_MODEL, "ollama": OLLAMA_PRIMARY_MODEL}
+# Backend defaults — overridable from config.json llm.models[<backend>].
+# Anthropic-compat backends share the same SDK code path; only base_url and
+# api_key_env differ. Ollama uses its own native HTTP API.
+BACKEND_DEFAULTS = {
+    "anthropic": {
+        "transport":   "anthropic",
+        "heavy":       "claude-sonnet-4-5",
+        "light":       "claude-haiku-4-5-20251001",
+        "base_url":    None,                  # SDK default
+        "api_key_env": "ANTHROPIC_API_KEY",
+    },
+    "deepseek": {
+        "transport":   "anthropic",
+        "heavy":       "deepseek-v4-pro",
+        "light":       "deepseek-v4-flash",
+        "base_url":    "https://api.deepseek.com/anthropic",
+        "api_key_env": "DEEPSEEK_API_KEY",
+    },
+    "omlx": {
+        "transport":   "anthropic",
+        "heavy":       "Qwen3.6-35B-A3B-4bit",
+        "light":       "gemma-4-e4b-it-8bit",
+        "base_url":    "http://127.0.0.1:8000",
+        "api_key_env": "OMLX_API_KEY",
+    },
+    "ollama": {
+        "transport":   "ollama",
+        "heavy":       "deepseek-r1:8b",
+        "light":       "llama3.2:3b",
+        "base_url":    "http://localhost:11434",
+        "api_key_env": None,
+    },
+}
+
+VALID_BACKENDS = tuple(BACKEND_DEFAULTS.keys())
 
 
 # ---------------------------------------------------------------------------
@@ -81,12 +111,22 @@ DEFAULT_MODEL_ENTRY = {"claude": CLAUDE_PRIMARY_MODEL, "ollama": OLLAMA_PRIMARY_
 
 class LLMClient:
     def __init__(self):
-        self.anthropic_client = None
         self._load_env_first()
-        self._init_anthropic()
+        self._backends = self._build_backend_config()
+        self._active_backend_name   = self._resolve_active_backend()
+        self._fallback_backend_name = self._resolve_fallback_backend()
+        self._anthropic_clients: dict[str, Anthropic] = {}
+        logger.info(
+            f"LLM router initialized — active: {self._active_backend_name}, "
+            f"fallback: {self._fallback_backend_name or 'none'}"
+        )
+
+    # -----------------------------------------------------------------------
+    # Setup
+    # -----------------------------------------------------------------------
 
     def _load_env_first(self):
-        """Load .env before initializing clients — keys.py may not have run yet."""
+        """Load .env before reading env vars — keys.py may not have run yet."""
         from pathlib import Path
         env_path = Path(__file__).parent.parent / ".env"
         if not env_path.exists():
@@ -103,83 +143,215 @@ class LLMClient:
                     if key and value and key not in os.environ:
                         os.environ[key] = value
 
-    def _init_anthropic(self):
-        api_key = os.environ.get("ANTHROPIC_API_KEY")
-        if not api_key:
-            logger.warning("ANTHROPIC_API_KEY not set — will fall back to Ollama immediately")
-            return
+    def _build_backend_config(self) -> dict:
+        """Merge config.json llm.models overrides on top of BACKEND_DEFAULTS."""
+        merged = {name: dict(cfg) for name, cfg in BACKEND_DEFAULTS.items()}
         try:
-            self.anthropic_client = Anthropic(api_key=api_key)
-            logger.info("Anthropic client initialized successfully")
+            from core.utils import load_config
+            cfg = load_config()
         except Exception as e:
-            logger.warning(f"Failed to initialize Anthropic client: {e}")
-            self.anthropic_client = None
+            logger.debug(f"config.json not loaded for llm overrides: {e}")
+            return merged
+        llm_cfg = cfg.get("llm", {})
+        for name, override in llm_cfg.get("models", {}).items():
+            if name not in merged:
+                logger.warning(f"config.json llm.models has unknown backend: {name}")
+                continue
+            merged[name].update({k: v for k, v in override.items() if v is not None})
+        return merged
 
-    def _ensure_anthropic(self):
-        """Re-check key in case it was set after initial import — lazy init."""
-        if self.anthropic_client is None:
-            self._load_env_first()
-            self._init_anthropic()
+    def _resolve_active_backend(self) -> str:
+        """Resolution order: LLM_BACKEND env → config.json llm.backend → legacy auto-detect."""
+        env_choice = os.environ.get("LLM_BACKEND", "").strip().lower()
+        if env_choice:
+            if env_choice not in VALID_BACKENDS:
+                raise ValueError(
+                    f"LLM_BACKEND={env_choice!r} is not one of {VALID_BACKENDS}"
+                )
+            return env_choice
 
-    def _get_models(self, agent_name: str) -> dict:
-        return AGENT_MODEL_MAP.get(agent_name.lower(), DEFAULT_MODEL_ENTRY)
+        try:
+            from core.utils import load_config
+            cfg_choice = load_config().get("llm", {}).get("backend", "").strip().lower()
+        except Exception:
+            cfg_choice = ""
+        if cfg_choice:
+            if cfg_choice not in VALID_BACKENDS:
+                raise ValueError(
+                    f"config.json llm.backend={cfg_choice!r} is not one of {VALID_BACKENDS}"
+                )
+            return cfg_choice
+
+        # Legacy auto-detect
+        return "anthropic" if os.environ.get("ANTHROPIC_API_KEY", "").strip() else "ollama"
+
+    def _resolve_fallback_backend(self) -> Optional[str]:
+        """Cross-backend fallback is opt-in. None means 'no cross-backend fallback'."""
+        env_choice = os.environ.get("LLM_FALLBACK_BACKEND", "").strip().lower()
+        if env_choice:
+            if env_choice not in VALID_BACKENDS:
+                raise ValueError(
+                    f"LLM_FALLBACK_BACKEND={env_choice!r} is not one of {VALID_BACKENDS}"
+                )
+            if env_choice == self._active_backend_name:
+                return None
+            return env_choice
+
+        try:
+            from core.utils import load_config
+            cfg_choice = load_config().get("llm", {}).get("fallback_backend")
+        except Exception:
+            cfg_choice = None
+        if not cfg_choice:
+            return None
+        cfg_choice = str(cfg_choice).strip().lower()
+        if cfg_choice not in VALID_BACKENDS:
+            raise ValueError(
+                f"config.json llm.fallback_backend={cfg_choice!r} is not one of {VALID_BACKENDS}"
+            )
+        if cfg_choice == self._active_backend_name:
+            return None
+        return cfg_choice
 
     # -----------------------------------------------------------------------
-    # Claude API call
+    # Introspection
     # -----------------------------------------------------------------------
 
-    def _call_claude(
+    def active_backend(self) -> str:
+        return self._active_backend_name
+
+    def fallback_backend(self) -> Optional[str]:
+        return self._fallback_backend_name
+
+    def active_backend_status(self) -> tuple[bool, str]:
+        """
+        Returns (ok, human-readable detail). Used by main.py's startup banner
+        and by `python3 main.py keys`.
+        """
+        return self._backend_status(self._active_backend_name)
+
+    def _backend_status(self, name: str) -> tuple[bool, str]:
+        cfg = self._backends[name]
+        if cfg["transport"] == "anthropic":
+            api_key_env = cfg["api_key_env"]
+            key_set = bool(os.environ.get(api_key_env, "").strip())
+            base = cfg["base_url"] or "api.anthropic.com"
+            if key_set:
+                return True, f"{api_key_env} set, base_url={base}"
+            return False, f"{api_key_env} not set (base_url={base})"
+        # ollama
+        try:
+            resp = requests.get(f"{cfg['base_url']}/api/tags", timeout=2)
+            if resp.status_code == 200:
+                return True, f"reachable at {cfg['base_url']}"
+            return False, f"HTTP {resp.status_code} from {cfg['base_url']}"
+        except Exception as e:
+            return False, f"unreachable at {cfg['base_url']} ({type(e).__name__})"
+
+    # -----------------------------------------------------------------------
+    # Anthropic-compatible client cache
+    # -----------------------------------------------------------------------
+
+    def _anthropic_client_for(self, backend: str) -> Optional[Anthropic]:
+        cfg = self._backends[backend]
+        if cfg["transport"] != "anthropic":
+            return None
+        if backend in self._anthropic_clients:
+            return self._anthropic_clients[backend]
+
+        api_key = os.environ.get(cfg["api_key_env"], "").strip()
+        if not api_key:
+            logger.warning(
+                f"[{backend}] {cfg['api_key_env']} not set — backend is unavailable"
+            )
+            return None
+        try:
+            kwargs = {"api_key": api_key}
+            if cfg["base_url"]:
+                kwargs["base_url"] = cfg["base_url"]
+            client = Anthropic(**kwargs)
+            self._anthropic_clients[backend] = client
+            logger.info(f"[{backend}] Anthropic-compatible client initialized")
+            return client
+        except Exception as e:
+            logger.warning(f"[{backend}] Failed to initialize client: {e}")
+            return None
+
+    # -----------------------------------------------------------------------
+    # Per-call model selection
+    # -----------------------------------------------------------------------
+
+    def _models_for(self, backend: str, agent_name: str) -> dict:
+        """
+        Return the (primary, fallback) model pair for this agent on this
+        backend. Heavy agents call the heavy model and fall back to light;
+        light agents call the light model directly with no within-backend
+        fallback (it's already the cheap model).
+        """
+        cfg = self._backends[backend]
+        tier = AGENT_TIER.get(agent_name.lower(), "heavy")
+        if tier == "heavy":
+            return {"primary": cfg["heavy"], "fallback": cfg["light"]}
+        return {"primary": cfg["light"], "fallback": cfg["light"]}
+
+    # -----------------------------------------------------------------------
+    # Anthropic-compatible call (anthropic, deepseek, omlx)
+    # -----------------------------------------------------------------------
+
+    def _call_anthropic_compat(
         self,
+        backend: str,
         prompt: str,
         system: str,
         model: str,
         agent_name: str
     ) -> Optional[str]:
-        if not self.anthropic_client:
+        client = self._anthropic_client_for(backend)
+        if not client:
             return None
 
         for attempt in range(1, MAX_API_RETRIES + 1):
             try:
-                logger.info(f"[{agent_name}] Claude API call — model: {model} — attempt {attempt}/{MAX_API_RETRIES}")
-                response = self.anthropic_client.messages.create(
+                logger.info(
+                    f"[{agent_name}] {backend} call — model: {model} "
+                    f"— attempt {attempt}/{MAX_API_RETRIES}"
+                )
+                response = client.messages.create(
                     model=model,
                     max_tokens=AGENT_MAX_TOKENS.get(agent_name.lower(), MAX_TOKENS),
                     system=system,
                     messages=[{"role": "user", "content": prompt}]
                 )
                 text = response.content[0].text
-                logger.info(f"[{agent_name}] Claude API success — {len(text)} chars returned")
+                logger.info(f"[{agent_name}] {backend} success — {len(text)} chars returned")
                 return text
 
             except RateLimitError as e:
-                logger.warning(f"[{agent_name}] Rate limited — attempt {attempt}: {e}")
+                logger.warning(f"[{agent_name}] {backend} rate limited — attempt {attempt}: {e}")
                 if attempt < MAX_API_RETRIES:
-                    wait = RETRY_DELAY_SECONDS * attempt
-                    logger.info(f"[{agent_name}] Waiting {wait}s before retry...")
-                    time.sleep(wait)
+                    time.sleep(RETRY_DELAY_SECONDS * attempt)
 
             except APIConnectionError as e:
-                logger.warning(f"[{agent_name}] Connection error — attempt {attempt}: {e}")
+                logger.warning(f"[{agent_name}] {backend} connection error — attempt {attempt}: {e}")
                 if attempt < MAX_API_RETRIES:
                     time.sleep(RETRY_DELAY_SECONDS)
 
             except APIStatusError as e:
-                logger.error(f"[{agent_name}] API status error {e.status_code}: {e.message}")
-                # 5xx errors are retryable, 4xx are not
+                logger.error(f"[{agent_name}] {backend} status {e.status_code}: {e.message}")
                 if e.status_code >= 500 and attempt < MAX_API_RETRIES:
                     time.sleep(RETRY_DELAY_SECONDS)
                 else:
                     return None
 
             except Exception as e:
-                logger.error(f"[{agent_name}] Unexpected Claude error: {e}")
+                logger.error(f"[{agent_name}] {backend} unexpected error: {e}")
                 return None
 
-        logger.error(f"[{agent_name}] Claude API exhausted all retries")
+        logger.error(f"[{agent_name}] {backend} exhausted all retries")
         return None
 
     # -----------------------------------------------------------------------
-    # Ollama local call
+    # Ollama call
     # -----------------------------------------------------------------------
 
     def _call_ollama(
@@ -189,7 +361,8 @@ class LLMClient:
         model: str,
         agent_name: str
     ) -> Optional[str]:
-        url = f"{OLLAMA_BASE_URL}/api/chat"
+        base_url = self._backends["ollama"]["base_url"]
+        url = f"{base_url}/api/chat"
         payload = {
             "model": model,
             "messages": [
@@ -204,16 +377,16 @@ class LLMClient:
         }
 
         try:
-            logger.info(f"[{agent_name}] Ollama call — model: {model}")
+            logger.info(f"[{agent_name}] ollama call — model: {model}")
             resp = requests.post(url, json=payload, timeout=300)
             resp.raise_for_status()
             data = resp.json()
             text = data["message"]["content"]
-            logger.info(f"[{agent_name}] Ollama success — {len(text)} chars returned")
+            logger.info(f"[{agent_name}] ollama success — {len(text)} chars returned")
             return text
 
         except requests.exceptions.ConnectionError:
-            logger.error(f"[{agent_name}] Ollama not reachable at {OLLAMA_BASE_URL} — is it running?")
+            logger.error(f"[{agent_name}] Ollama not reachable at {base_url} — is it running?")
             return None
 
         except requests.exceptions.Timeout:
@@ -225,15 +398,54 @@ class LLMClient:
             return None
 
     def _check_ollama_model(self, model: str) -> bool:
-        """Check if a model is available in Ollama."""
+        base_url = self._backends["ollama"]["base_url"]
         try:
-            resp = requests.get(f"{OLLAMA_BASE_URL}/api/tags", timeout=5)
+            resp = requests.get(f"{base_url}/api/tags", timeout=5)
             resp.raise_for_status()
             models = [m["name"] for m in resp.json().get("models", [])]
-            # Check exact or prefix match
             return any(m == model or m.startswith(model.split(":")[0]) for m in models)
         except Exception:
             return False
+
+    # -----------------------------------------------------------------------
+    # Dispatch
+    # -----------------------------------------------------------------------
+
+    def _invoke(
+        self,
+        backend: str,
+        prompt: str,
+        system: str,
+        model: str,
+        agent_name: str
+    ) -> Optional[str]:
+        transport = self._backends[backend]["transport"]
+        if transport == "anthropic":
+            return self._call_anthropic_compat(backend, prompt, system, model, agent_name)
+        if transport == "ollama":
+            if not self._check_ollama_model(model):
+                logger.warning(f"[{agent_name}] Ollama model {model} not available")
+                return None
+            return self._call_ollama(prompt, system, model, agent_name)
+        logger.error(f"[{agent_name}] Unknown transport for backend {backend}: {transport}")
+        return None
+
+    def _try_backend(
+        self,
+        backend: str,
+        prompt: str,
+        system: str,
+        agent_name: str
+    ) -> Optional[str]:
+        """Try the backend's primary model, then its fallback model if different."""
+        models = self._models_for(backend, agent_name)
+        result = self._invoke(backend, prompt, system, models["primary"], agent_name)
+        if result is not None:
+            return result
+        if models["fallback"] != models["primary"]:
+            logger.info(f"[{agent_name}] {backend}: primary failed, trying fallback model {models['fallback']}")
+            return self._invoke(backend, prompt, system, models["fallback"], agent_name)
+        return None
 
     # -----------------------------------------------------------------------
     # Main public interface
@@ -247,55 +459,35 @@ class LLMClient:
         force_local: bool = False
     ) -> str:
         """
-        Route LLM call with automatic fallback.
-        
-        Priority:
-          1. Claude API (primary model for agent)
-          2. Claude API (haiku fallback within API)
-          3. Ollama primary model
-          4. Ollama light model
-          5. Raise exception — nothing available
+        Route an LLM call.
+
+        Order:
+          1. Active backend's heavy model
+          2. Active backend's light model (skipped if same as heavy)
+          3. Cross-backend fallback (only if configured) — heavy then light
+          4. Raise RuntimeError
+
+        force_local=True overrides backend selection and uses ollama directly
+        (kept for backward compat; no current caller passes this).
         """
-        models = self._get_models(agent_name)
+        primary_backend = "ollama" if force_local else self._active_backend_name
+        result = self._try_backend(primary_backend, prompt, system, agent_name)
+        if result is not None:
+            return result
 
-        # Ensure client is initialized — handles case where .env was not loaded at import time
-        if not force_local:
-            self._ensure_anthropic()
-
-        # Step 1: Try Claude API
-        if not force_local and self.anthropic_client:
-            result = self._call_claude(prompt, system, models["claude"], agent_name)
-            if result:
+        if not force_local and self._fallback_backend_name:
+            logger.info(
+                f"[{agent_name}] {primary_backend} failed — trying fallback backend "
+                f"{self._fallback_backend_name}"
+            )
+            result = self._try_backend(self._fallback_backend_name, prompt, system, agent_name)
+            if result is not None:
                 return result
 
-            # Step 2: Try cheaper Claude model if primary failed
-            if models["claude"] != CLAUDE_FALLBACK_MODEL:
-                logger.info(f"[{agent_name}] Trying Claude fallback model: {CLAUDE_FALLBACK_MODEL}")
-                result = self._call_claude(prompt, system, CLAUDE_FALLBACK_MODEL, agent_name)
-                if result:
-                    return result
-
-        # Step 3: Try Ollama primary model
-        logger.info(f"[{agent_name}] Falling back to Ollama — model: {models['ollama']}")
-        if self._check_ollama_model(models["ollama"]):
-            result = self._call_ollama(prompt, system, models["ollama"], agent_name)
-            if result:
-                return result
-        else:
-            logger.warning(f"[{agent_name}] Ollama model {models['ollama']} not available — trying light model")
-
-        # Step 4: Try Ollama light model
-        if models["ollama"] != OLLAMA_LIGHT_MODEL:
-            logger.info(f"[{agent_name}] Trying Ollama light model: {OLLAMA_LIGHT_MODEL}")
-            if self._check_ollama_model(OLLAMA_LIGHT_MODEL):
-                result = self._call_ollama(prompt, system, OLLAMA_LIGHT_MODEL, agent_name)
-                if result:
-                    return result
-
-        # Step 5: Nothing worked
         raise RuntimeError(
             f"[{agent_name}] All LLM backends failed. "
-            f"Check ANTHROPIC_API_KEY and Ollama availability."
+            f"Active: {primary_backend}, fallback: {self._fallback_backend_name or 'none'}. "
+            f"Check API keys and backend availability."
         )
 
 
@@ -305,11 +497,19 @@ class LLMClient:
 
 _client: Optional[LLMClient] = None
 
+
 def get_client() -> LLMClient:
     global _client
     if _client is None:
         _client = LLMClient()
     return _client
+
+
+def reset_client() -> None:
+    """Drop the cached client. Tests use this after mutating env or config."""
+    global _client
+    _client = None
+
 
 def call(
     prompt: str,

--- a/main.py
+++ b/main.py
@@ -423,18 +423,29 @@ def _agent_done(run_id: str, agent: str) -> bool:
 # ---------------------------------------------------------------------------
 
 def cmd_run(args):
-    # Check ANTHROPIC_API_KEY is available before starting
     import os
     from core import llm as llm_module
+
+    # --backend CLI flag wins; export to env so the LLM router (and any
+    # later subprocess) sees it. Reset the cached client so the new
+    # backend selection takes effect.
+    if getattr(args, "backend", None):
+        os.environ["LLM_BACKEND"] = args.backend
+        llm_module.reset_client()
+
     client = llm_module.get_client()
-    if client.anthropic_client is None:
-        print("\n  ⚠️  WARNING: ANTHROPIC_API_KEY is not set or not loaded.")
-        print("     The pipeline will use Ollama (local) for all LLM calls.")
-        print("     To use Claude API: add ANTHROPIC_API_KEY to your .env file.")
-        print("     Continuing in 5 seconds...\n")
+    active = client.active_backend()
+    fallback = client.fallback_backend()
+    ok, detail = client.active_backend_status()
+
+    print(f"\n  Backend: {active}  {'✅' if ok else '⚠️ '} {detail}")
+    print(f"  Fallback backend: {fallback or 'none (within-backend fallback only)'}")
+    if not ok:
+        print(f"     The active backend is not ready. Fix the credential / endpoint")
+        print(f"     and re-run, or pick a different backend with --backend / LLM_BACKEND.")
+        print(f"     Continuing in 5 seconds...\n")
         import time; time.sleep(5)
-    else:
-        print("\n  ✅  Claude API key loaded — using Claude for all agents.")
+
     run_pipeline(
         problem=args.problem,
         run_id=args.run_id,
@@ -640,6 +651,9 @@ Commands:
     p_run.add_argument("--problem", required=True, help="Research problem statement")
     p_run.add_argument("--run-id",  default=None,  help="Resume an existing run")
     p_run.add_argument("--resume",  action="store_true", help="Resume from last completed step")
+    p_run.add_argument("--backend", choices=["anthropic", "deepseek", "omlx", "ollama"],
+                       default=None,
+                       help="LLM backend (overrides LLM_BACKEND env and config.json llm.backend)")
     p_run.set_defaults(func=cmd_run)
 
     # collect

--- a/tests/test_llm_backends.py
+++ b/tests/test_llm_backends.py
@@ -1,0 +1,294 @@
+"""
+Test: LLM backend router (4-backend fan-out)
+---------------------------------------------
+Verifies backend selection, within-backend fallback (heavy→light model),
+opt-in cross-backend fallback, and that each backend dispatches through the
+correct transport (Anthropic SDK vs Ollama HTTP).
+
+No live API calls. Mocks at the SDK / HTTP boundary.
+
+Run as a standalone script:  python3 tests/test_llm_backends.py
+Or under pytest:             python3 -m pytest tests/test_llm_backends.py -v
+"""
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+# Wipe LLM-related env so test runs don't see your shell config.
+for _v in ("LLM_BACKEND", "LLM_FALLBACK_BACKEND",
+           "ANTHROPIC_API_KEY", "DEEPSEEK_API_KEY", "OMLX_API_KEY"):
+    os.environ.pop(_v, None)
+
+
+_LLM_ENV_KEYS = ("LLM_BACKEND", "LLM_FALLBACK_BACKEND",
+                 "ANTHROPIC_API_KEY", "DEEPSEEK_API_KEY", "OMLX_API_KEY")
+
+
+def _fresh_client(env: dict):
+    """Reset the singleton, wipe LLM env, then apply this test's env, build a client."""
+    from core import llm
+    llm.reset_client()
+    for k in _LLM_ENV_KEYS:
+        os.environ.pop(k, None)
+    for k, v in env.items():
+        if v is None:
+            os.environ.pop(k, None)
+        else:
+            os.environ[k] = v
+    return llm, llm.get_client()
+
+
+def _fake_anthropic_response(text: str = "ok"):
+    """Build a mock that mimics anthropic.messages.create() return shape."""
+    msg = MagicMock()
+    msg.content = [MagicMock(text=text)]
+    return msg
+
+
+# ─── Test 1: Resolution order ──────────────────────────────────────────────
+
+def test_resolution_order_env_wins_over_config():
+    llm, c = _fresh_client({"LLM_BACKEND": "omlx"})
+    assert c.active_backend() == "omlx", c.active_backend()
+    print("✓ env LLM_BACKEND overrides config.json default (anthropic)")
+
+
+def test_resolution_legacy_auto_detect_anthropic():
+    """No env, ANTHROPIC_API_KEY present → anthropic. config.json default also says anthropic, so this is consistent."""
+    llm, c = _fresh_client({"ANTHROPIC_API_KEY": "sk-test-fake"})
+    assert c.active_backend() == "anthropic"
+    print("✓ legacy auto-detect picks anthropic when key is set")
+
+
+def test_invalid_backend_raises():
+    from core import llm as _llm
+    _llm.reset_client()
+    os.environ["LLM_BACKEND"] = "gpt-7"
+    try:
+        _llm.get_client()
+        assert False, "should have raised ValueError"
+    except ValueError as e:
+        assert "gpt-7" in str(e)
+    finally:
+        os.environ.pop("LLM_BACKEND", None)
+    print("✓ invalid LLM_BACKEND raises ValueError")
+
+
+def test_fallback_equals_active_collapses_to_none():
+    llm, c = _fresh_client({"LLM_BACKEND": "omlx", "LLM_FALLBACK_BACKEND": "omlx"})
+    assert c.fallback_backend() is None
+    print("✓ fallback_backend == active collapses to None")
+
+
+# ─── Test 2: Per-agent tier (heavy vs light) ───────────────────────────────
+
+def test_models_for_heavy_agent():
+    llm, c = _fresh_client({"LLM_BACKEND": "deepseek"})
+    m = c._models_for("deepseek", "grounder")
+    assert m == {"primary": "deepseek-v4-pro", "fallback": "deepseek-v4-flash"}, m
+    print("✓ heavy agent (grounder) → primary=heavy, fallback=light")
+
+
+def test_models_for_light_agent():
+    llm, c = _fresh_client({"LLM_BACKEND": "deepseek"})
+    m = c._models_for("deepseek", "social")
+    assert m == {"primary": "deepseek-v4-flash", "fallback": "deepseek-v4-flash"}, m
+    print("✓ light agent (social) → primary=fallback=light (no within-backend retry)")
+
+
+# ─── Test 3: Anthropic-compat dispatch (anthropic, deepseek, omlx) ─────────
+
+def test_anthropic_compat_dispatch_for_anthropic():
+    llm, c = _fresh_client({"LLM_BACKEND": "anthropic", "ANTHROPIC_API_KEY": "sk-anthropic"})
+    fake = MagicMock()
+    fake.messages.create.return_value = _fake_anthropic_response("hello")
+    with patch("core.llm.Anthropic", return_value=fake) as ctor:
+        out = c.call("p", "s", "grounder")
+    assert out == "hello"
+    # Called once for client construction, with anthropic key, no base_url override
+    ctor.assert_called_once_with(api_key="sk-anthropic")
+    fake.messages.create.assert_called_once()
+    assert fake.messages.create.call_args.kwargs["model"] == "claude-sonnet-4-5"
+    print("✓ anthropic backend → Anthropic() with no base_url, heavy model")
+
+
+def test_anthropic_compat_dispatch_for_deepseek():
+    llm, c = _fresh_client({"LLM_BACKEND": "deepseek", "DEEPSEEK_API_KEY": "sk-deepseek"})
+    fake = MagicMock()
+    fake.messages.create.return_value = _fake_anthropic_response("ds")
+    with patch("core.llm.Anthropic", return_value=fake) as ctor:
+        out = c.call("p", "s", "grounder")
+    assert out == "ds"
+    ctor.assert_called_once_with(
+        api_key="sk-deepseek",
+        base_url="https://api.deepseek.com/anthropic",
+    )
+    assert fake.messages.create.call_args.kwargs["model"] == "deepseek-v4-pro"
+    print("✓ deepseek backend → Anthropic(base_url=deepseek) with DEEPSEEK_API_KEY, deepseek-v4-pro")
+
+
+def test_anthropic_compat_dispatch_for_omlx():
+    llm, c = _fresh_client({"LLM_BACKEND": "omlx", "OMLX_API_KEY": "sk-omlx"})
+    fake = MagicMock()
+    fake.messages.create.return_value = _fake_anthropic_response("local")
+    with patch("core.llm.Anthropic", return_value=fake) as ctor:
+        out = c.call("p", "s", "grounder")
+    assert out == "local"
+    ctor.assert_called_once_with(api_key="sk-omlx", base_url="http://127.0.0.1:8000")
+    assert fake.messages.create.call_args.kwargs["model"] == "Qwen3.6-35B-A3B-4bit"
+    print("✓ omlx backend → Anthropic(base_url=127.0.0.1:8000) with OMLX_API_KEY, Qwen3.6 model")
+
+
+def test_deepseek_does_not_use_anthropic_api_key():
+    """The DeepSeek docs say 'ANTHROPIC_API_KEY corresponds to x-api-key' but that's
+    misleading for our setup — we must NOT read $ANTHROPIC_API_KEY when the user
+    selected the deepseek backend, or the real Anthropic key would leak."""
+    llm, c = _fresh_client({
+        "LLM_BACKEND": "deepseek",
+        "ANTHROPIC_API_KEY": "sk-DO-NOT-LEAK",
+        "DEEPSEEK_API_KEY":  "sk-deepseek-correct",
+    })
+    fake = MagicMock()
+    fake.messages.create.return_value = _fake_anthropic_response("ok")
+    with patch("core.llm.Anthropic", return_value=fake) as ctor:
+        c.call("p", "s", "grounder")
+    args = ctor.call_args
+    assert args.kwargs["api_key"] == "sk-deepseek-correct"
+    assert "sk-DO-NOT-LEAK" not in str(args)
+    print("✓ deepseek does NOT use $ANTHROPIC_API_KEY (no key leak)")
+
+
+# ─── Test 4: Within-backend fallback (heavy → light) ───────────────────────
+
+def test_within_backend_fallback_for_heavy_agent():
+    """If heavy model returns None, the router calls the light model."""
+    llm, c = _fresh_client({"LLM_BACKEND": "deepseek", "DEEPSEEK_API_KEY": "k"})
+    fake = MagicMock()
+    # First create() raises a 5xx-style error → returns None internally; second succeeds.
+    from anthropic import APIStatusError
+    err = APIStatusError(message="server error", response=MagicMock(status_code=500), body=None)
+    err.status_code = 500
+    fake.messages.create.side_effect = [err, err, err, _fake_anthropic_response("recovered")]
+    with patch("core.llm.Anthropic", return_value=fake):
+        out = c.call("p", "s", "grounder")
+    assert out == "recovered"
+    # Verify the second call used the light model
+    last_model = fake.messages.create.call_args.kwargs["model"]
+    assert last_model == "deepseek-v4-flash", last_model
+    print("✓ within-backend fallback: heavy fails → light model invoked")
+
+
+# ─── Test 5: Cross-backend fallback (opt-in only) ──────────────────────────
+
+def test_no_cross_backend_fallback_by_default_raises():
+    """With fallback_backend=None, total backend failure raises RuntimeError."""
+    llm, c = _fresh_client({"LLM_BACKEND": "deepseek", "DEEPSEEK_API_KEY": "k"})
+    assert c.fallback_backend() is None
+    fake = MagicMock()
+    from anthropic import APIStatusError
+    err = APIStatusError(message="bad request", response=MagicMock(status_code=400), body=None)
+    err.status_code = 400  # 4xx is not retryable → returns None immediately
+    fake.messages.create.side_effect = err
+    with patch("core.llm.Anthropic", return_value=fake):
+        try:
+            c.call("p", "s", "grounder")
+            assert False, "should have raised"
+        except RuntimeError as e:
+            assert "deepseek" in str(e)
+    print("✓ no cross-backend fallback by default → raises RuntimeError")
+
+
+def test_cross_backend_fallback_when_configured():
+    """With LLM_FALLBACK_BACKEND=ollama, primary failure routes to Ollama."""
+    llm, c = _fresh_client({
+        "LLM_BACKEND":          "deepseek",
+        "DEEPSEEK_API_KEY":     "k",
+        "LLM_FALLBACK_BACKEND": "ollama",
+    })
+    assert c.fallback_backend() == "ollama"
+
+    fake_anthropic = MagicMock()
+    from anthropic import APIStatusError
+    err = APIStatusError(message="bad", response=MagicMock(status_code=400), body=None)
+    err.status_code = 400
+    fake_anthropic.messages.create.side_effect = err
+
+    # Mock ollama side: /api/tags reports model present, /api/chat returns text.
+    def fake_get(url, *a, **kw):
+        r = MagicMock()
+        r.status_code = 200
+        r.raise_for_status.return_value = None
+        r.json.return_value = {"models": [{"name": "deepseek-r1:8b"}]}
+        return r
+
+    def fake_post(url, *a, **kw):
+        r = MagicMock()
+        r.raise_for_status.return_value = None
+        r.json.return_value = {"message": {"content": "ollama-saved-the-day"}}
+        return r
+
+    with patch("core.llm.Anthropic", return_value=fake_anthropic), \
+         patch("core.llm.requests.get", side_effect=fake_get), \
+         patch("core.llm.requests.post", side_effect=fake_post):
+        out = c.call("p", "s", "grounder")
+
+    assert out == "ollama-saved-the-day", out
+    print("✓ cross-backend fallback fires only when LLM_FALLBACK_BACKEND is set")
+
+
+# ─── Test 6: Backend status introspection ──────────────────────────────────
+
+def test_active_backend_status_anthropic():
+    llm, c = _fresh_client({"LLM_BACKEND": "anthropic", "ANTHROPIC_API_KEY": "x"})
+    ok, detail = c.active_backend_status()
+    assert ok is True
+    assert "ANTHROPIC_API_KEY" in detail
+    print("✓ active_backend_status reports anthropic OK when key set")
+
+
+def test_active_backend_status_omlx_missing_key():
+    llm, c = _fresh_client({"LLM_BACKEND": "omlx"})
+    ok, detail = c.active_backend_status()
+    assert ok is False
+    assert "OMLX_API_KEY" in detail
+    print("✓ active_backend_status reports omlx not-ready when key missing")
+
+
+# ─── Driver ────────────────────────────────────────────────────────────────
+
+if __name__ == "__main__":
+    tests = [
+        test_resolution_order_env_wins_over_config,
+        test_resolution_legacy_auto_detect_anthropic,
+        test_invalid_backend_raises,
+        test_fallback_equals_active_collapses_to_none,
+        test_models_for_heavy_agent,
+        test_models_for_light_agent,
+        test_anthropic_compat_dispatch_for_anthropic,
+        test_anthropic_compat_dispatch_for_deepseek,
+        test_anthropic_compat_dispatch_for_omlx,
+        test_deepseek_does_not_use_anthropic_api_key,
+        test_within_backend_fallback_for_heavy_agent,
+        test_no_cross_backend_fallback_by_default_raises,
+        test_cross_backend_fallback_when_configured,
+        test_active_backend_status_anthropic,
+        test_active_backend_status_omlx_missing_key,
+    ]
+    failed = 0
+    for fn in tests:
+        try:
+            fn()
+        except AssertionError as e:
+            print(f"✗ {fn.__name__}: {e}")
+            failed += 1
+        except Exception as e:
+            print(f"✗ {fn.__name__}: unexpected {type(e).__name__}: {e}")
+            failed += 1
+    print()
+    if failed:
+        print(f"FAILED: {failed}/{len(tests)}")
+        sys.exit(1)
+    print(f"ALL PASSED: {len(tests)}/{len(tests)}")


### PR DESCRIPTION
## Summary
- Adds two new LLM backends: **DeepSeek** (cloud, Anthropic-compatible endpoint) and **oMLX** (local Anthropic-compatible server).
- Replaces the implicit Anthropic-vs-Ollama auto-pick with explicit backend selection: `--backend` CLI flag > `LLM_BACKEND` env > `config.json` `llm.backend` > legacy auto-detect.
- **Behavior change**: cross-backend fallback is now opt-in (`LLM_FALLBACK_BACKEND` or `config.json` `llm.fallback_backend`, default `null`). Within-backend heavy→light fallback stays automatic.
- Three of four backends (`anthropic`, `deepseek`, `omlx`) collapse onto one `Anthropic()` SDK code path; only Ollama keeps its own transport.
- Also lands `CLAUDE.md` (architecture notes) from an earlier `/init` pass.

## Backend table
| Backend | Heavy / Light | API key | Base URL |
|---|---|---|---|
| `anthropic` | `claude-sonnet-4-5` / `claude-haiku-4-5-20251001` | `ANTHROPIC_API_KEY` | SDK default |
| `deepseek` | `deepseek-v4-pro` / `deepseek-v4-flash` | `DEEPSEEK_API_KEY` | `https://api.deepseek.com/anthropic` |
| `omlx` | `Qwen3.6-35B-A3B-4bit` / `gemma-4-e4b-it-8bit` | `OMLX_API_KEY` | `http://127.0.0.1:8000` |
| `ollama` | `deepseek-r1:8b` / `llama3.2:3b` | none | `http://localhost:11434` |

## Security note
DeepSeek's docs say the `x-api-key` header maps to `ANTHROPIC_API_KEY`. The router instead reads `DEEPSEEK_API_KEY` and passes it explicitly to the SDK so the real Anthropic key never leaks to a non-Anthropic backend. There is a regression test for this.

## Test plan
- [x] `python3 -m pytest tests/test_llm_backends.py -v` — 15 / 15 pass
- [x] `python3 tests/test_llm_backends.py` — runs as standalone script too
- [x] Existing tests still pass (`tests/test_grounder_tree.py`, `tests/test_context_tree.py`)
- [x] `python3 main.py run --help` shows the new `--backend {anthropic,deepseek,omlx,ollama}` flag
- [x] `python3 main.py keys` prints "Backend: X ✅/⚠️ detail (fallback: Y)" header
- [x] `LLM_BACKEND=deepseek DEEPSEEK_API_KEY=… main.py keys` correctly switches and reports `https://api.deepseek.com/anthropic` base URL
- [ ] Live smoke test against real DeepSeek and oMLX endpoints (needs real keys / running server — left for reviewer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)